### PR TITLE
High RAM usage shouldn't terminate script

### DIFF
--- a/plb.py
+++ b/plb.py
@@ -254,6 +254,7 @@ def cluster_load_verification(mem_load: float, cluster_obj: object) -> bool:
     if mem_load >= THRESHOLD:
         logger.warning(f'Cluster RAM usage is too high {(round(cluster_obj.mem_load * 100, 2))}')
         logger.warning('It is not possible to safely balance the cluster')
+        send_mail(f'Cluster RAM usage is too high {(round(cluster_obj.mem_load * 100, 2))}')
         return False
     return True
 


### PR DESCRIPTION
Sometimes, I have a short-term situation on my cluster where I spin up a lot of VMs for a while, causing high memory utilisation. As this condition goes away once those VMs are destroyed, I don't think a high-RAM condition should permanently kill the load-balancer.

I've modified the `cluster_load_verification` slightly to return a status on a recoverable failure. The main loop then sees the low-memory condition as something it can try again later.

