### PR TITLE
Feature/only run on master

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,6 +14,7 @@ parameters:
   threshold: 90            # Percentage of maximum load
   lxc_migration: OFF       # Container migration (LXCs are rebooted during migration!!!)
   migration_timeout: 1000  # For the future
+  only_on_master: OFF      # Only run PLB on the current cluster master
 
 # List of exclusions
 exclusions:

--- a/plb.py
+++ b/plb.py
@@ -7,6 +7,7 @@ import requests
 import urllib3
 import yaml
 import smtplib
+import socket
 from random import random
 from email.message import EmailMessage
 from time import sleep
@@ -30,6 +31,7 @@ CONFIG_DEVIATION = CD = cfg["parameters"]["deviation"] / 200
 THRESHOLD = cfg["parameters"]["threshold"] / 100
 LXC_MIGRATION = cfg["parameters"]["lxc_migration"]
 MIGRATION_TIMEOUT = cfg["parameters"]["migration_timeout"]
+ONLY_ON_MASTER = cfg["parameters"]["only_on_master"]
 
 """Exclusions"""
 excluded_vms = tuple(cfg["exclusions"]["vms"])
@@ -72,6 +74,8 @@ class Cluster:
         """Cluster"""
         self.server: str = server
         self.cl_name = self.cluster_name()
+        self.master_node: str = None
+        self.quorate: bool = False
         """VMs and nodes"""
         self.cl_nodes: int = 0                      # The number of nodes. Calculated in Cluster.cluster_name
         self.cluster_information = {}               # Retrieved in Cluster.cluster_items
@@ -136,6 +140,24 @@ class Cluster:
         """Getting nodes from cluster resources"""
         logger.debug("Launching Cluster.cluster_hosts")
         nodes_dict = {}
+
+        # Find out which node is the current cluster master
+        url = f'{self.server}/api2/json/cluster/ha/status/manager_status'
+        logger.debug('Attempt to get information about the cluster HA manager...')
+        resources_request = rr = requests.get(url, cookies=payload, verify=False)
+        if resources_request.ok:
+            logger.debug(f'Information about the cluster HA Manager has been received. Response code: {rr.status_code}')
+        else:
+            logger.warning(f'Execution error {Cluster.cluster_items.__qualname__}')
+            logger.warning(f'Could not get information about the HA cluster manager. Response code: {rr.status_code}. Reason: ({rr.reason})')
+            sys.exit(0)
+
+        self.master_node = rr.json()['data']['manager_status']['master_node']
+        self.quorate = (rr.json()['data']['quorum']['quorate'] == "1")
+        if self.quorate == False:
+            # This is probably an error condition that should cause a "try again later"
+            logger.warning(f'Quorum is currently not quorate!')
+
         temp = deepcopy(self.cluster_information)
         for item in temp:
             if item["type"] == "node":
@@ -143,7 +165,9 @@ class Cluster:
                 item["cpu_used"] = round(item["maxcpu"] * item["cpu"], 2)   # Adding the value of the cores used
                 item["free_mem"] = item["maxmem"] - item["mem"]             # Adding the value of free RAM
                 item["mem_load"] = item["mem"] / item["maxmem"]             # Adding the RAM load value
+                item["is_master"] = (item["node"] == self.master_node)      # Flagging the current master node
                 nodes_dict[item["node"]] = item
+
                 if item["node"] not in excluded_nodes:
                     self.included_nodes[item["node"]] = item
         del temp
@@ -414,6 +438,15 @@ def main():
     global iteration
     authentication(server_url, auth)
     cluster = Cluster(server_url)
+    
+    if ONLY_ON_MASTER:
+        hostname = socket.gethostname()
+        master = cluster.master_node
+        if hostname != master:
+            logger.info(f'This server ({hostname}) is not the current cluster master, {master} is. Waiting 300 seconds.')
+            sleep(300)
+            return
+
     verification_status = cluster_load_verification(cluster.mem_load_included, cluster)
     if verification_status == False:
         logger.warning('Cluster health verification failed. Waiting 300 seconds.')
@@ -430,6 +463,7 @@ def main():
             logger.info('Waiting 10 seconds for cluster information update')
             sleep(10)
         else:
+            sleep(60)
             pass  # TODO Aggressive algorithm
     else:
         logger.info('The cluster is balanced. Waiting 300 seconds.')

--- a/plb.py
+++ b/plb.py
@@ -31,7 +31,7 @@ CONFIG_DEVIATION = CD = cfg["parameters"]["deviation"] / 200
 THRESHOLD = cfg["parameters"]["threshold"] / 100
 LXC_MIGRATION = cfg["parameters"]["lxc_migration"]
 MIGRATION_TIMEOUT = cfg["parameters"]["migration_timeout"]
-ONLY_ON_MASTER = cfg["parameters"]["only_on_master"]
+ONLY_ON_MASTER = cfg["parameters"].get("only_on_master", False)
 
 """Exclusions"""
 excluded_vms = tuple(cfg["exclusions"]["vms"])
@@ -452,6 +452,7 @@ def main():
         logger.warning('Cluster health verification failed. Waiting 300 seconds.')
         sleep(300)
         return
+
     need_to_balance = need_to_balance_checking(cluster)
     logger.info(f'Need to balance: {need_to_balance}')
     if need_to_balance:


### PR DESCRIPTION
Not sure if this is a direction you wanted to go in with PLB, but I've added a capability for the script to determine if it's running on a cluster master node, and only run if it is. This means I can configure all my proxmox hosts identically using ansible, but the script only actually does anything on one node, even if the cluster HA reconfigures itself.

* if you set `only_on_master` to `ON`, the script will skip migrating any VMs if `hostname != cluster_master`.
* defaults to `OFF` because if you're running it from a different machine altogether, it would never run.
* defaults to `OFF` if the `only_on_master` is not in config.yml, to prevent users having to update config on upgrade.
